### PR TITLE
Fit-in should be before requested size.

### DIFF
--- a/src/main/java/com/squareup/pollexor/Pollexor.java
+++ b/src/main/java/com/squareup/pollexor/Pollexor.java
@@ -447,6 +447,9 @@ public final class Pollexor {
     }
 
     if (hasResize) {
+      if (fitIn) {
+        builder.append(PART_FIT_IN).append("/");
+      }
       if (flipHorizontally) {
         builder.append("-");
       }
@@ -455,10 +458,6 @@ public final class Pollexor {
         builder.append("-");
       }
       builder.append(resizeHeight);
-
-      if (fitIn) {
-        builder.append("/").append(PART_FIT_IN);
-      }
       builder.append("/");
     }
 

--- a/src/test/java/com/squareup/pollexor/PollexorTest.java
+++ b/src/test/java/com/squareup/pollexor/PollexorTest.java
@@ -147,7 +147,7 @@ public class PollexorTest {
     assertFalse(url.fitIn);
     url.fitIn();
     assertTrue(url.fitIn);
-    assertEquals("/unsafe/10x5/fit-in/a.com/b.png", url.toUrl());
+    assertEquals("/unsafe/fit-in/10x5/a.com/b.png", url.toUrl());
   }
 
   @Test public void testResizeAndFlip() {


### PR DESCRIPTION
According to thumbor documentation /fit-in/ argument should be before requested size: https://github.com/globocom/thumbor/wiki/Usage. Different order unfortunatelly doesn't work. When will be possiblity to release the new version to maven central?
