### PR TITLE
Do not mutate input URLs. Thumbor 3.0 can handle protocol and path params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Version 1.2.0 *(In Development)*
+--------------------------------
+
+ * Fix: Do not mutate input image URLs. Thumbor 3.0 now supports full URLs in
+   the request.
+
+
 Version 1.1.2 *(2013-03-05)*
 ----------------------------
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -49,7 +49,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
-            <property name="max" value="120"/>
+            <property name="max" value="100"/>
         </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>

--- a/src/main/java/com/squareup/pollexor/Pollexor.java
+++ b/src/main/java/com/squareup/pollexor/Pollexor.java
@@ -8,7 +8,6 @@ import static com.squareup.pollexor.Utilities.aes128Encrypt;
 import static com.squareup.pollexor.Utilities.base64Encode;
 import static com.squareup.pollexor.Utilities.hmacSha1;
 import static com.squareup.pollexor.Utilities.md5;
-import static com.squareup.pollexor.Utilities.stripProtocolAndParams;
 
 /**
  * Fluent interface to create a URL appropriate for passing to Thumbor.
@@ -33,9 +32,7 @@ public final class Pollexor {
   private static final String FILTER_FRAME = "frame";
   private static final String FILTER_STRIP_ICC = "strip_icc";
 
-  /**
-   * Horizontal alignment for crop positioning.
-   */
+  /** Horizontal alignment for crop positioning. */
   public enum HorizontalAlign {
     LEFT("left"), CENTER("center"), RIGHT("right");
 
@@ -46,9 +43,7 @@ public final class Pollexor {
     }
   }
 
-  /**
-   * Vertical alignment for crop positioning.
-   */
+  /** Vertical alignment for crop positioning. */
   public enum VerticalAlign {
     TOP("top"), MIDDLE("middle"), BOTTOM("bottom");
 
@@ -60,7 +55,8 @@ public final class Pollexor {
   }
 
   /**
-   * Exception denoting that a fatal error occurred while assembling the URL for the current configuration.
+   * Exception denoting that a fatal error occurred while assembling the URL for the current
+   * configuration.
    *
    * @see #getCause()
    */
@@ -100,7 +96,7 @@ public final class Pollexor {
    * @param target Target image URL.
    */
   Pollexor(String target) {
-    this.target = stripProtocolAndParams(target);
+    this.target = target;
   }
 
   /**
@@ -117,8 +113,8 @@ public final class Pollexor {
   }
 
   /**
-   * Set a key for secure URL generation. This will default the {@link #toUrl()} and {@link #toMeta()} to build safe
-   * URLs.
+   * Set a key for secure URL generation. This will default the {@link #toUrl()} and
+   * {@link #toMeta()} to build safe URLs.
    *
    * @param key Security key for remote server.
    * @throws UnableToBuildException if {@code key} is blank.
@@ -151,7 +147,7 @@ public final class Pollexor {
   /**
    * Resize picture to desired size.
    *
-   * @param width  Desired width.
+   * @param width Desired width.
    * @param height Desired height.
    * @throws UnableToBuildException if {@code width} or {@code height} is less than 1.
    */
@@ -210,13 +206,13 @@ public final class Pollexor {
   /**
    * Crop the image between two points.
    *
-   * @param top    Top bound.
-   * @param left   Left bound.
+   * @param top Top bound.
+   * @param left Left bound.
    * @param bottom Bottom bound.
-   * @param right  Right bound.
-   * @throws UnableToBuildException if {@code top} or {@code left} are less than zero or {@code bottom} or
-   *                                {@code right} are less than one or less than {@code top} or {@code left},
-   *                                respectively.
+   * @param right Right bound.
+   * @throws UnableToBuildException if {@code top} or {@code left} are less than zero or {@code
+   * bottom} or {@code right} are less than one or less than {@code top} or {@code left},
+   * respectively.
    */
   public Pollexor crop(int top, int left, int bottom, int right) {
     if (top < 0) {
@@ -291,18 +287,17 @@ public final class Pollexor {
     return this;
   }
 
-  /**
-   * Use legacy encryption when constructing a safe URL.
-   */
+  /** Use legacy encryption when constructing a safe URL. */
   public Pollexor legacy() {
     isLegacy = true;
     return this;
   }
 
   /**
-   * <p>Add one or more filters to the image.</p>
-   * <p/>
-   * <p>If you have custom filters you can supply them as a string. (e.g. <code>"my_filter(1,2,3)</code>").</p>
+   * Add one or more filters to the image.
+   * <p>
+   * If you have custom filters you can supply them as a string. (e.g.
+   * <code>"my_filter(1,2,3)</code>").
    *
    * @param filters Filter strings.
    * @throws UnableToBuildException if no arguments supplied or an argument is {@code null}.
@@ -341,8 +336,8 @@ public final class Pollexor {
   }
 
   /**
-   * Build the URL. This will either call {@link #toUrlSafe()} or {@link #toUrlUnsafe()} depending on whether
-   * {@link #key(String)} was set.
+   * Build the URL. This will either call {@link #toUrlSafe()} or {@link #toUrlUnsafe()} depending
+   * on whether {@link #key(String)} was set.
    *
    * @throws UnableToBuildException
    */
@@ -350,9 +345,7 @@ public final class Pollexor {
     return (key == null) ? toUrlUnsafe() : toUrlSafe();
   }
 
-  /**
-   * Build an unsafe version of the URL.
-   */
+  /** Build an unsafe version of the URL. */
   public String toUrlUnsafe() {
     return host + PREFIX_UNSAFE + assembleConfig(false);
   }
@@ -382,8 +375,8 @@ public final class Pollexor {
   }
 
   /**
-   * Build the metadata URL. This will either call {@link #toMetaSafe()} or {@link #toMetaUnsafe()} depending on whether
-   * {@link #key(String)} was set.
+   * Build the metadata URL. This will either call {@link #toMetaSafe()} or {@link #toMetaUnsafe()}
+   * depending on whether {@link #key(String)} was set.
    *
    * @throws UnableToBuildException
    */
@@ -391,9 +384,7 @@ public final class Pollexor {
     return (key == null) ? toMetaUnsafe() : toMetaSafe();
   }
 
-  /**
-   * Build an unsafe version of the metadata URL.
-   */
+  /** Build an unsafe version of the metadata URL. */
   public String toMetaUnsafe() {
     return host + assembleConfig(true);
   }
@@ -419,9 +410,7 @@ public final class Pollexor {
     return toUrl();
   }
 
-  /**
-   * Assemble the configuration section of the URL.
-   */
+  /** Assemble the configuration section of the URL. */
   StringBuilder assembleConfig(boolean meta) {
     StringBuilder builder = new StringBuilder();
 
@@ -478,7 +467,7 @@ public final class Pollexor {
    * This filter increases or decreases the image brightness.
    *
    * @param amount -100 to 100 - The amount (in %) to change the image brightness. Positive numbers
-   *               make the image brighter and negative numbers make the image darker.
+   * make the image brighter and negative numbers make the image darker.
    * @throws UnableToBuildException if {@code amount} outside bounds.
    */
   public static String brightness(int amount) {
@@ -492,7 +481,7 @@ public final class Pollexor {
    * The filter increases or decreases the image contrast.
    *
    * @param amount -100 to 100 - The amount (in %) to change the image contrast. Positive numbers
-   *               increase contrast and negative numbers decrease contrast.
+   * increase contrast and negative numbers decrease contrast.
    * @throws UnableToBuildException if {@code amount} outside bounds.
    */
   public static String contrast(int amount) {
@@ -562,7 +551,7 @@ public final class Pollexor {
    * This filter adds rounded corners to the image using the specified color as the background.
    *
    * @param radius amount of pixels to use as radius.
-   * @param color  fill color for clipped region.
+   * @param color fill color for clipped region.
    */
   public static String roundCorner(int radius, int color) {
     return roundCorner(radius, 0, color);
@@ -573,8 +562,8 @@ public final class Pollexor {
    *
    * @param radiusInner amount of pixels to use as radius.
    * @param radiusOuter specifies the second value for the ellipse used for the radius. Use 0 for
-   *                    no value.
-   * @param color       fill color for clipped region.
+   * no value.
+   * @param color fill color for clipped region.
    */
   public static String roundCorner(int radiusInner, int radiusOuter, int color) {
     if (radiusInner < 1) {
@@ -601,7 +590,7 @@ public final class Pollexor {
    * This filter adds a watermark to the image at (0, 0).
    *
    * @param imageUrl Watermark image URL. It is very important to understand that the same image
-   *                 loader that Thumbor uses will be used here.
+   * loader that Thumbor uses will be used here.
    * @throws UnableToBuildException if {@code image} is blank.
    */
   public static String watermark(String imageUrl) {
@@ -612,7 +601,7 @@ public final class Pollexor {
    * This filter adds a watermark to the image at (0, 0).
    *
    * @param image Watermark image URL. It is very important to understand that the same image
-   *              loader that Thumbor uses will be used here.
+   * loader that Thumbor uses will be used here.
    * @throws UnableToBuildException if {@code image} is null.
    */
   public static String watermark(Pollexor image) {
@@ -623,11 +612,11 @@ public final class Pollexor {
    * This filter adds a watermark to the image.
    *
    * @param imageUrl Watermark image URL. It is very important to understand that the same image
-   *                 loader that Thumbor uses will be used here.
-   * @param x        Horizontal position that the watermark will be in. Positive numbers indicate position
-   *                 from the left and negative numbers indicate position from the right.
-   * @param y        Vertical position that the watermark will be in. Positive numbers indicate position
-   *                 from the top and negative numbers indicate position from the bottom.
+   * loader that Thumbor uses will be used here.
+   * @param x Horizontal position that the watermark will be in. Positive numbers indicate position
+   * from the left and negative numbers indicate position from the right.
+   * @param y Vertical position that the watermark will be in. Positive numbers indicate position
+   * from the top and negative numbers indicate position from the bottom.
    * @throws UnableToBuildException if {@code image} is blank.
    */
   public static String watermark(String imageUrl, int x, int y) {
@@ -638,11 +627,11 @@ public final class Pollexor {
    * This filter adds a watermark to the image.
    *
    * @param image Watermark image URL. It is very important to understand that the same image
-   *              loader that Thumbor uses will be used here.
-   * @param x     Horizontal position that the watermark will be in. Positive numbers indicate position
-   *              from the left and negative numbers indicate position from the right.
-   * @param y     Vertical position that the watermark will be in. Positive numbers indicate position
-   *              from the top and negative numbers indicate position from the bottom.
+   * loader that Thumbor uses will be used here.
+   * @param x Horizontal position that the watermark will be in. Positive numbers indicate position
+   * from the left and negative numbers indicate position from the right.
+   * @param y Vertical position that the watermark will be in. Positive numbers indicate position
+   * from the top and negative numbers indicate position from the bottom.
    * @throws UnableToBuildException if {@code image} is null.
    */
   public static String watermark(Pollexor image, int x, int y) {
@@ -655,15 +644,16 @@ public final class Pollexor {
   /**
    * This filter adds a watermark to the image.
    *
-   * @param imageUrl     Watermark image URL. It is very important to understand that the same image
-   *                     loader that Thumbor uses will be used here.
-   * @param x            Horizontal position that the watermark will be in. Positive numbers indicate position
-   *                     from the left and negative numbers indicate position from the right.
-   * @param y            Vertical position that the watermark will be in. Positive numbers indicate position
-   *                     from the top and negative numbers indicate position from the bottom.
+   * @param imageUrl Watermark image URL. It is very important to understand that the same image
+   * loader that Thumbor uses will be used here.
+   * @param x Horizontal position that the watermark will be in. Positive numbers indicate position
+   * from the left and negative numbers indicate position from the right.
+   * @param y Vertical position that the watermark will be in. Positive numbers indicate position
+   * from the top and negative numbers indicate position from the bottom.
    * @param transparency Watermark image transparency. Should be a number between 0 (fully opaque)
-   *                     and 100 (fully transparent).
-   * @throws UnableToBuildException if {@code image} is blank or {@code transparency} is outside bounds.
+   * and 100 (fully transparent).
+   * @throws UnableToBuildException if {@code image} is blank or {@code transparency} is outside
+   * bounds.
    */
   public static String watermark(String imageUrl, int x, int y, int transparency) {
     if (imageUrl == null || imageUrl.length() == 0) {
@@ -672,20 +662,20 @@ public final class Pollexor {
     if (transparency < 0 || transparency > 100) {
       throw new UnableToBuildException("Transparency must be between 0 and 100, inclusive.");
     }
-    return FILTER_WATERMARK + "(" + stripProtocolAndParams(imageUrl) + "," + x + "," + y + "," + transparency + ")";
+    return FILTER_WATERMARK + "(" + imageUrl + "," + x + "," + y + "," + transparency + ")";
   }
 
   /**
    * This filter adds a watermark to the image.
    *
-   * @param image        Watermark image URL. It is very important to understand that the same image
-   *                     loader that Thumbor uses will be used here.
-   * @param x            Horizontal position that the watermark will be in. Positive numbers indicate position
-   *                     from the left and negative numbers indicate position from the right.
-   * @param y            Vertical position that the watermark will be in. Positive numbers indicate position
-   *                     from the top and negative numbers indicate position from the bottom.
+   * @param image Watermark image URL. It is very important to understand that the same image
+   * loader that Thumbor uses will be used here.
+   * @param x Horizontal position that the watermark will be in. Positive numbers indicate position
+   * from the left and negative numbers indicate position from the right.
+   * @param y Vertical position that the watermark will be in. Positive numbers indicate position
+   * from the top and negative numbers indicate position from the bottom.
    * @param transparency Watermark image transparency. Should be a number between 0 (fully opaque)
-   *                     and 100 (fully transparent).
+   * and 100 (fully transparent).
    * @throws UnableToBuildException if {@code image} is null.
    */
   public static String watermark(Pollexor image, int x, int y, int transparency) {
@@ -700,8 +690,8 @@ public final class Pollexor {
    * excellent Wavelet sharpen GIMP plugin. Check http://registry.gimp.org/node/9836 for details
    * about how it work.
    *
-   * @param amount        Sharpen amount. Typical values are between 0.0 and 10.0.
-   * @param radius        Sharpen radius. Typical values are between 0.0 and 2.0.
+   * @param amount Sharpen amount. Typical values are between 0.0 and 10.0.
+   * @param radius Sharpen radius. Typical values are between 0.0 and 2.0.
    * @param luminanceOnly Sharpen only luminance channel.
    */
   public static String sharpen(float amount, float radius, boolean luminanceOnly) {
@@ -723,18 +713,16 @@ public final class Pollexor {
    * This filter uses a 9-patch to overlay the image.
    *
    * @param imageUrl Watermark image URL. It is very important to understand that the same image
-   *                 loader that Thumbor uses will be used here.
+   * loader that Thumbor uses will be used here.
    */
   public static String frame(String imageUrl) {
     if (imageUrl == null || imageUrl.length() == 0) {
       throw new UnableToBuildException("Image URL must not be blank.");
     }
-    return FILTER_FRAME + "(" + stripProtocolAndParams(imageUrl) + ")";
+    return FILTER_FRAME + "(" + imageUrl + ")";
   }
 
-  /**
-   * This filter strips the ICC profile from the image.
-   */
+  /** This filter strips the ICC profile from the image. */
   public static String stripicc() {
     return FILTER_STRIP_ICC + "()";
   }

--- a/src/main/java/com/squareup/pollexor/Utilities.java
+++ b/src/main/java/com/squareup/pollexor/Utilities.java
@@ -8,9 +8,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.MessageDigest;
 
-/**
- * Utility methods for {@link Pollexor}.
- */
+/** Utility methods for {@link Pollexor}. */
 final class Utilities {
   private Utilities() {
     // No instances.
@@ -25,14 +23,16 @@ final class Utilities {
    *
    * @param bytes Bytes to encode.
    * @return Encoded string.
-   * @throws IllegalArgumentException if {@code bytes} is null or exceeds 3/4ths of {@code Integer.MAX_VALUE}.
+   * @throws IllegalArgumentException if {@code bytes} is null or exceeds 3/4ths of {@code
+   * Integer.MAX_VALUE}.
    */
   public static String base64Encode(byte[] bytes) {
     if (bytes == null) {
       throw new IllegalArgumentException("Input bytes must not be null.");
     }
     if (bytes.length >= BASE64_UPPER_BOUND) {
-      throw new IllegalArgumentException("Input bytes length must not exceed " + BASE64_UPPER_BOUND);
+      throw new IllegalArgumentException(
+          "Input bytes length must not exceed " + BASE64_UPPER_BOUND);
     }
 
     // Every three bytes is encoded into four characters.
@@ -75,48 +75,13 @@ final class Utilities {
   }
 
   /**
-   * Remove any protocol or parameters from the specified URL.
-   *
-   * @param url URL.
-   * @return Stripped URL.
-   */
-  static String stripProtocolAndParams(String url) {
-    if (url == null) {
-      return null;
-    }
-
-    final int length = url.length();
-
-    int start = 0;
-    int end = length;
-
-    // Only truncate 'http' protocol since it is the default.
-    if (url.startsWith("http://")) {
-      start = 7;
-    }
-
-    int param = url.indexOf("?");
-    if (param != -1) {
-      end = param;
-    }
-    param = url.indexOf("#");
-    if (param != -1 && param < end) {
-      end = param;
-    }
-
-    if (start > 0 || end < length) {
-      return url.substring(start, end);
-    }
-    return url;
-  }
-
-  /**
    * Pad a {@link StringBuilder} to a desired multiple on the right using a specified character.
    *
    * @param builder Builder to pad.
    * @param padding Padding character.
    * @param multipleOf Number which the length must be a multiple of.
-   * @throws IllegalArgumentException if {@code builder} is null or {@code multipleOf} is less than 2.
+   * @throws IllegalArgumentException if {@code builder} is null or {@code multipleOf} is less than
+   * 2.
    */
   static void rightPadString(StringBuilder builder, char padding, int multipleOf) {
     if (builder == null) {
@@ -138,8 +103,10 @@ final class Utilities {
    *
    * @param string Input string.
    * @param desiredLength Desired length of string.
-   * @return Output string which is guaranteed to have a length equal to the desired length argument.
-   * @throws IllegalArgumentException if {@code string} is blank or {@code desiredLength} is not greater than 0.
+   * @return Output string which is guaranteed to have a length equal to the desired length
+   *         argument.
+   * @throws IllegalArgumentException if {@code string} is blank or {@code desiredLength} is not
+   * greater than 0.
    */
   static String normalizeString(String string, int desiredLength) {
     if (string == null || string.length() == 0) {

--- a/src/test/java/com/squareup/pollexor/PollexorTest.java
+++ b/src/test/java/com/squareup/pollexor/PollexorTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.fail;
 
 public class PollexorTest {
   @Test public void testNoConfig() {
-    assertEquals("/unsafe/a.com/b.png", image("http://a.com/b.png").toUrl());
+    assertEquals("/unsafe/http://a.com/b.png", image("http://a.com/b.png").toUrl());
   }
 
   @Test public void testComplexUnsafeBuild() {

--- a/src/test/java/com/squareup/pollexor/UtilitiesTest.java
+++ b/src/test/java/com/squareup/pollexor/UtilitiesTest.java
@@ -7,34 +7,10 @@ import static com.squareup.pollexor.Utilities.base64Encode;
 import static com.squareup.pollexor.Utilities.md5;
 import static com.squareup.pollexor.Utilities.normalizeString;
 import static com.squareup.pollexor.Utilities.rightPadString;
-import static com.squareup.pollexor.Utilities.stripProtocolAndParams;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class UtilitiesTest {
-  @Test public void testProtocolAndParamStrip() {
-    assertNull(stripProtocolAndParams(null));
-    assertEquals("", stripProtocolAndParams(""));
-    assertEquals("hi.com", stripProtocolAndParams("http://hi.com"));
-    assertEquals("hi.com", stripProtocolAndParams("hi.com?whatup"));
-    assertEquals("hi.com", stripProtocolAndParams("hi.com#whatup"));
-    assertEquals("hi.com", stripProtocolAndParams("hi.com?what#up"));
-    assertEquals("hi.com", stripProtocolAndParams("hi.com#what?up"));
-    assertEquals("hi.com/hi.html", stripProtocolAndParams("http://hi.com/hi.html"));
-    assertEquals("hi.com/hi.html", stripProtocolAndParams("hi.com/hi.html?whatup"));
-    assertEquals("hi.com/hi.html", stripProtocolAndParams("http://hi.com/hi.html?whatup"));
-    assertEquals("hi.com/hi.html", stripProtocolAndParams("http://hi.com/hi.html?http://whatever.com"));
-    assertEquals("hi.com/http://whatever.com", stripProtocolAndParams("http://hi.com/http://whatever.com"));
-    assertEquals("hi.com/http://whatever.com", stripProtocolAndParams("http://hi.com/http://whatever.com?whatup"));
-    assertEquals("https://hi.com", stripProtocolAndParams("https://hi.com"));
-    assertEquals("https://hi.com/hi.html", stripProtocolAndParams("https://hi.com/hi.html"));
-    assertEquals("https://hi.com/hi.html", stripProtocolAndParams("https://hi.com/hi.html?whatup"));
-    assertEquals("ftp://hi.com", stripProtocolAndParams("ftp://hi.com"));
-    assertEquals("ftp://hi.com/hi.html", stripProtocolAndParams("ftp://hi.com/hi.html"));
-    assertEquals("ftp://hi.com/hi.html", stripProtocolAndParams("ftp://hi.com/hi.html?whatup"));
-  }
-
   @Test public void testKeyNormalization() {
     assertEquals("oneoneoneo", normalizeString("one", 10));
     assertEquals("equaltoten", normalizeString("equaltoten", 10));
@@ -86,7 +62,8 @@ public class UtilitiesTest {
   @Test public void testBase64() {
     assertEquals("", base64Encode(new byte[0]));
     assertEquals("dGVzdA==", base64Encode("test".getBytes()));
-    assertEquals("dGhpcyBpcyBhIHJlYWxseSBsb25nIHN0cmluZw==", base64Encode("this is a really long string".getBytes()));
+    assertEquals("dGhpcyBpcyBhIHJlYWxseSBsb25nIHN0cmluZw==",
+        base64Encode("this is a really long string".getBytes()));
   }
 
   @Test public void testBase64InvalidInputs() {


### PR DESCRIPTION
Closes #5.

This also normalizes our JavaDoc and line wrapping to the current standard.
