### PR TITLE
Add proper URL encoding option.

### DIFF
--- a/src/main/java/com/squareup/pollexor/ThumborUrlBuilder.java
+++ b/src/main/java/com/squareup/pollexor/ThumborUrlBuilder.java
@@ -369,7 +369,14 @@ public final class ThumborUrlBuilder {
    * on whether a key was set.
    */
   public String toUrl() {
-    return (key == null) ? toUrlUnsafe() : toUrlSafe();
+    return (key == null) ? toUrlUnsafe() : toUrlSafe(false);
+  }
+
+  /**
+   * Build the URL. Same as {@link #toUrl()}, but with '=' encoded as '%3D'.
+   */
+  public String toEncodedUrl() {
+    return (key == null) ? toUrlUnsafe() : toUrlSafe(true);
   }
 
   /** Build an unsafe version of the URL. */
@@ -381,6 +388,14 @@ public final class ThumborUrlBuilder {
    * Build a safe version of the URL. Requires a non-{@code null} key.
    */
   public String toUrlSafe() {
+    return toUrlSafe(false);
+  }
+
+  /**
+   * Build a safe version of the URL. Requires a non-{@code null} key.
+   * @param urlEncode Build url encoded version without illegal '=' character.
+   */
+  public String toUrlSafe(boolean urlEncode) {
     if (key == null) {
       throw new IllegalStateException("Cannot build safe URL without a key.");
     }
@@ -392,6 +407,11 @@ public final class ThumborUrlBuilder {
     String encoded = base64Encode(encrypted);
 
     CharSequence suffix = legacy ? image : config;
+
+    if (urlEncode) {
+      encoded = encoded.replace("=", "%3D");
+    }
+
     return host + encoded + "/" + suffix;
   }
 
@@ -412,9 +432,21 @@ public final class ThumborUrlBuilder {
    * Build a safe version of the metadata URL. Requires a non-{@code null} key.
    */
   public String toMetaSafe() {
+    return toMetaSafe(false);
+  }
+
+  /**
+   * Build a safe version of the metadata URL. Requires a non-{@code null} key.
+   * @param urlEncode Build url encoded version without illegal '=' character.
+   */
+  public String toMetaSafe(boolean urlEncode) {
     StringBuilder config = assembleConfig(true);
     byte[] encrypted = hmacSha1(config, key);
     String encoded = base64Encode(encrypted);
+
+    if (urlEncode) {
+      encoded = encoded.replace("=", "%3D");
+    }
 
     return host + encoded + "/" + config;
   }

--- a/src/test/java/com/squareup/pollexor/ThumborUrlBuilderTest.java
+++ b/src/test/java/com/squareup/pollexor/ThumborUrlBuilderTest.java
@@ -58,6 +58,18 @@ public class ThumborUrlBuilderTest {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @Test public void testComplexEncodedSafeBuild() {
+    String expected = "/X_5ze5WdyTObULp4Toj6mHX-R1U%3D/10x10:90x90/40x40/filters:watermark(/unsafe/20x20/b.com/c.jpg,10,10,0):round_corner(5,255,255,255)/a.com/b.png";
+    String actual = safe.buildImage("a.com/b.png")
+            .crop(10, 10, 90, 90)
+            .resize(40, 40)
+            .filter(
+                    watermark(unsafe.buildImage("b.com/c.jpg").resize(20, 20), 10, 10),
+                    roundCorner(5))
+            .toEncodedUrl();
+    assertThat(actual).isEqualTo(expected);
+  }
+
   @Test public void testComplexLegacySafeBuild() {
     String expected = "/xrUrWUD_ZhogPh-rvPF5VhgWENCgh-mzknoAEZ7dcX_xa7sjqP1ff9hQQq_ORAKmuCr5pyyU3srXG7BUdWUzBqp3AIucz8KiGsmHw1eFe4SBWhp1wSQNG49jSbbuHaFF_4jy5oV4Nh821F4yqNZfe6CIvjbrr1Vw2aMPL4bE7VCHBYE9ukKjVjLRiW3nLfih/a.com/b.png";
     String actual = safe.buildImage("a.com/b.png")

--- a/src/test/java/com/squareup/pollexor/UpstreamTest.java
+++ b/src/test/java/com/squareup/pollexor/UpstreamTest.java
@@ -21,9 +21,21 @@ public class UpstreamTest {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @Test public void matchingEncodedSignature() {
+    String expected = "/8ammJH8D-7tXy6kU3lTvoXlhu4o%3D/300x200/my.server.com/some/path/to/image.jpg";
+    String actual = url().resize(300, 200).toEncodedUrl();
+    assertThat(actual).isEqualTo(expected);
+  }
+
   @Test public void matchingSignatureWithMeta() {
     String expected = "/Ps3ORJDqxlSQ8y00T29GdNAh2CY=/meta/my.server.com/some/path/to/image.jpg";
     String actual = url().toMeta();
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test public void matchingEncodedSignatureWithMeta() {
+    String expected = "/Ps3ORJDqxlSQ8y00T29GdNAh2CY%3D/meta/my.server.com/some/path/to/image.jpg";
+    String actual = url().toMetaSafe(true);
     assertThat(actual).isEqualTo(expected);
   }
 
@@ -31,6 +43,13 @@ public class UpstreamTest {
     String expected =
         "/ZZtPCw-BLYN1g42Kh8xTcRs0Qls=/filters:brightness(10):contrast(20)/my.server.com/some/path/to/image.jpg";
     String actual = url().filter(brightness(10), contrast(20)).toUrl();
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test public void matchingEncodedSignatureWithFilters() {
+    String expected =
+            "/ZZtPCw-BLYN1g42Kh8xTcRs0Qls%3D/filters:brightness(10):contrast(20)/my.server.com/some/path/to/image.jpg";
+    String actual = url().filter(brightness(10), contrast(20)).toEncodedUrl();
     assertThat(actual).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
Add option to generate URLs that are properly URL encoded:

```
/ZZtPCw-BLYN1g42Kh8xTcRs0Qls=/my.server.com/some/path/to/image.jpg
```

becomes

```
/ZZtPCw-BLYN1g42Kh8xTcRs0Qls%3D/my.server.com/some/path/to/image.jpg
```

When using `toEncodedUrl()`

CLA accepted on Google Forms.