### PR TITLE
Change exception text for consistency and clarity.

### DIFF
--- a/src/main/java/com/squareup/pollexor/Thumbor.java
+++ b/src/main/java/com/squareup/pollexor/Thumbor.java
@@ -52,7 +52,7 @@ public final class Thumbor {
   /** Begin building a url for this host with the specified image. */
   public ThumborUrlBuilder buildImage(String image) {
     if (image == null || image.length() == 0) {
-      throw new IllegalArgumentException("Invalid image.");
+      throw new IllegalArgumentException("Image must not be blank.");
     }
     return new ThumborUrlBuilder(host, key, image);
   }


### PR DESCRIPTION
The existing error message "Invalid image" implies that there's something wrong with the image itself, when really it's a problem with its URL. The other IAEs in the file have the format "___ must not be blank", which I think is a clearer description of the problem.