### PR TITLE
/unsafe added to urls created by toMetaUnsafe()

### DIFF
--- a/src/main/java/com/squareup/pollexor/ThumborUrlBuilder.java
+++ b/src/main/java/com/squareup/pollexor/ThumborUrlBuilder.java
@@ -405,7 +405,7 @@ public final class ThumborUrlBuilder {
 
   /** Build an unsafe version of the metadata URL. */
   public String toMetaUnsafe() {
-    return host + assembleConfig(true);
+    return host + PREFIX_UNSAFE + assembleConfig(true);
   }
 
   /**


### PR DESCRIPTION
The meta url generator doesn't work as is for unsafe urls and should work the same way as the regular toUrlSafe method