### PR TITLE
Remove legacy() from ThumborUrlBuilder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,6 @@ thumbor.buildImage("http://example.com/background.png")
 // Produces: /unsafe/200x100/filters:round_corner(10,255,255,255):watermark(/unsafe/200x100/example.com/overlay1.png,0,0,0):watermark(/unsafe/50x50/example.com/overlay2.png,75,25,0):quality(85)/example.com/background.png
 ```
 
-*Note:* If you are using a version of Thumbor older than 3.0 you must call
-`legacy()` to ensure the encryption used will be supported by the server.
-
 
 
 License

--- a/src/main/java/com/squareup/pollexor/ThumborUrlBuilder.java
+++ b/src/main/java/com/squareup/pollexor/ThumborUrlBuilder.java
@@ -4,10 +4,8 @@ package com.squareup.pollexor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.squareup.pollexor.Utilities.aes128Encrypt;
 import static com.squareup.pollexor.Utilities.base64Encode;
 import static com.squareup.pollexor.Utilities.hmacSha1;
-import static com.squareup.pollexor.Utilities.md5;
 
 /**
  * Fluent interface to build a Thumbor URL.
@@ -103,7 +101,6 @@ public final class ThumborUrlBuilder {
   boolean hasResize;
   boolean isSmart;
   boolean isTrim;
-  boolean isLegacy;
   boolean flipHorizontally;
   boolean flipVertically;
   FitInStyle fitInStyle;
@@ -316,12 +313,6 @@ public final class ThumborUrlBuilder {
     return this;
   }
 
-  /** Use legacy encryption when constructing a safe URL. */
-  public ThumborUrlBuilder legacy() {
-    isLegacy = true;
-    return this;
-  }
-
   /**
    * Add one or more filters to the image.
    * <p>
@@ -385,14 +376,11 @@ public final class ThumborUrlBuilder {
       throw new IllegalStateException("Cannot build safe URL without a key.");
     }
 
-    boolean legacy = isLegacy;
-
     StringBuilder config = assembleConfig(false);
-    byte[] encrypted = legacy ? aes128Encrypt(config, key) : hmacSha1(config, key);
+    byte[] encrypted = hmacSha1(config, key);
     String encoded = base64Encode(encrypted);
 
-    CharSequence suffix = legacy ? image : config;
-    return host + encoded + "/" + suffix;
+    return host + encoded + "/" + config;
   }
 
   /**
@@ -491,7 +479,7 @@ public final class ThumborUrlBuilder {
       builder.append("/");
     }
 
-    builder.append(isLegacy ? md5(image) : image);
+    builder.append(image);
 
     return builder;
   }

--- a/src/main/java/com/squareup/pollexor/Utilities.java
+++ b/src/main/java/com/squareup/pollexor/Utilities.java
@@ -2,7 +2,6 @@
 package com.squareup.pollexor;
 
 import java.security.MessageDigest;
-import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -163,26 +162,6 @@ final class Utilities {
       Mac mac = Mac.getInstance("HmacSHA1");
       mac.init(new SecretKeySpec(key.getBytes(), "HmacSHA1"));
       return mac.doFinal(message.toString().getBytes());
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * Encrypt a string with AES-128 using the specified key.
-   *
-   * @param message Input string.
-   * @param key Encryption key.
-   * @return Encrypted output.
-   */
-  @SuppressWarnings("InsecureCryptoUsage") // Only used in known-weak crypto "legacy" mode.
-  static byte[] aes128Encrypt(StringBuilder message, String key) {
-    try {
-      key = normalizeString(key, 16);
-      rightPadString(message, '{', 16);
-      Cipher cipher = Cipher.getInstance("AES/ECB/NoPadding");
-      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key.getBytes(), "AES"));
-      return cipher.doFinal(message.toString().getBytes());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/squareup/pollexor/ThumborUrlBuilderTest.java
+++ b/src/test/java/com/squareup/pollexor/ThumborUrlBuilderTest.java
@@ -58,19 +58,6 @@ public class ThumborUrlBuilderTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  @Test public void testComplexLegacySafeBuild() {
-    String expected = "/xrUrWUD_ZhogPh-rvPF5VhgWENCgh-mzknoAEZ7dcX_xa7sjqP1ff9hQQq_ORAKmuCr5pyyU3srXG7BUdWUzBqp3AIucz8KiGsmHw1eFe4SBWhp1wSQNG49jSbbuHaFF_4jy5oV4Nh821F4yqNZfe6CIvjbrr1Vw2aMPL4bE7VCHBYE9ukKjVjLRiW3nLfih/a.com/b.png";
-    String actual = safe.buildImage("a.com/b.png")
-        .crop(10, 10, 90, 90)
-        .resize(40, 40)
-        .filter(
-            watermark(unsafe.buildImage("b.com/c.jpg").resize(20, 20), 10, 10),
-            roundCorner(5))
-        .legacy()
-        .toUrl();
-    assertThat(actual).isEqualTo(expected);
-  }
-
   @Test public void testKeyChangesToStringToSafeBuild() {
     ThumborUrlBuilder url1 = unsafe.buildImage("a.com/b.png");
     assertThat(url1.key).isNull();


### PR DESCRIPTION
Google Play Store has begun to display [warnings for app developers that are using ECB](https://support.google.com/faqs/answer/10046138).

aes128Encrypt() is only used if legacy() is called. I wasn't able to find anything in Github using the legacy() function, so it's probably safe to remove it:
https://github.com/search?l=Java&q=pollexor+legacy&type=Code
https://github.com/search?l=Kotlin&q=pollexor+legacy&type=Code

I ran `mvn clean verify` successfully.